### PR TITLE
fails build only if there are upgrade solutions available

### DIFF
--- a/lib/capistrano/tasks/bundle_audit.rake
+++ b/lib/capistrano/tasks/bundle_audit.rake
@@ -22,7 +22,10 @@ namespace :deploy do
               # bundle-audit includes failures for both gem vulnerabilities
               # and insecure gem sources, and offers no way to distinguish those cases.
               # unfortunately, we only want to fail when vulnerable gems are required.
-              if bundle_audit_output =~ /Name:/
+              # This should only fail if there is a bundle-audit output AND it has 
+              # a solution available to upgrade. If no solution is available deploy
+              # will still be allowed.
+              if bundle_audit_output =~ /Solution: upgrade to/
                 fail "Bundle audit failed; update your vulnerable dependencies before deploying"
               end
             end


### PR DESCRIPTION
Closes #2 
Rather than failing a build if a bundler-audit output is present, fail it if there is an upgrade solution.

There are really only two solutions from bundle-audit: 

https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/cli.rb#L124