### PR TITLE
replace with_clean_env with with_unbundled_env

### DIFF
--- a/lib/capistrano/tasks/bundle_audit.rake
+++ b/lib/capistrano/tasks/bundle_audit.rake
@@ -17,7 +17,7 @@ namespace :deploy do
             run_locally do
               capture %(echo 'gem "bundler-audit"' > Gemfile)
 
-              bundle_audit_output = Bundler.with_clean_env do
+              bundle_audit_output = Bundler.with_unbundled_env do
                 capture "bundle-audit check --update #{"--ignore #{Shellwords.join(fetch(:bundle_audit_ignore))}" unless fetch(:bundle_audit_ignore).empty? }"
               end
 


### PR DESCRIPTION
Error:
Bundler::RemovedError: [REMOVED] `Bundler.with_clean_env` has been removed in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (Bundler::RemovedError)